### PR TITLE
EVM: Add intent and proposal to executor interface

### DIFF
--- a/packages/evm/contracts/Settler.sol
+++ b/packages/evm/contracts/Settler.sol
@@ -77,7 +77,7 @@ contract Settler is ISettler, Ownable, ReentrancyGuard, EIP712 {
 
     /**
      * @dev It allows receiving native token transfers
-     * Note: This method mainly allow supporting native tokes for swaps
+     * Note: This method mainly allows supporting native tokens for swaps
      */
     receive() external payable {
         // solhint-disable-previous-line no-empty-blocks
@@ -157,7 +157,7 @@ contract Settler is ISettler, Ownable, ReentrancyGuard, EIP712 {
         }
 
         uint256[] memory preBalancesOut = _getTokensOutBalance(swapIntent);
-        IExecutor(swapProposal.executor).execute(swapProposal.data);
+        IExecutor(swapProposal.executor).execute(intent, proposal);
 
         if (swapIntent.destinationChain == block.chainid) {
             for (uint256 i = 0; i < swapIntent.tokensOut.length; i++) {

--- a/packages/evm/contracts/interfaces/IExecutor.sol
+++ b/packages/evm/contracts/interfaces/IExecutor.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.20;
 
+import '../Intents.sol';
+
 interface IExecutor {
-    function execute(bytes memory data) external;
+    function execute(Intent memory intent, Proposal memory proposal) external;
 }

--- a/packages/evm/contracts/test/executors/EmptyExecutorMock.sol
+++ b/packages/evm/contracts/test/executors/EmptyExecutorMock.sol
@@ -7,7 +7,7 @@ import '../../interfaces/IExecutor.sol';
 contract EmptyExecutorMock is IExecutor {
     event Executed();
 
-    function execute(bytes memory) external override {
+    function execute(Intent memory, Proposal memory) external override {
         emit Executed();
     }
 }

--- a/packages/evm/contracts/test/executors/MintExecutorMock.sol
+++ b/packages/evm/contracts/test/executors/MintExecutorMock.sol
@@ -5,13 +5,19 @@ pragma solidity ^0.8.20;
 import '../TokenMock.sol';
 import '../../interfaces/IExecutor.sol';
 
+/* solhint-disable custom-errors */
+
 contract MintExecutorMock is IExecutor {
     event Minted();
 
-    function execute(bytes memory data) external override {
-        (address[] memory tokens, uint256[] memory amounts) = abi.decode(data, (address[], uint256[]));
-        // solhint-disable-next-line custom-errors
+    function execute(Intent memory intent, Proposal memory proposal) external override {
+        require(intent.op == OpType.Swap, 'Invalid intent type');
+
+        SwapProposal memory swapProposal = abi.decode(proposal.data, (SwapProposal));
+        (address[] memory tokens, uint256[] memory amounts) = abi.decode(swapProposal.data, (address[], uint256[]));
+
         require(tokens.length == amounts.length, 'Invalid inputs');
+
         for (uint256 i = 0; i < tokens.length; i++) {
             TokenMock(tokens[i]).mint(msg.sender, amounts[i]);
             emit Minted();

--- a/packages/evm/contracts/test/executors/ReentrantExecutorMock.sol
+++ b/packages/evm/contracts/test/executors/ReentrantExecutorMock.sol
@@ -13,8 +13,11 @@ contract ReentrantExecutorMock is IExecutor {
         settler = _settler;
     }
 
-    function execute(bytes memory data) external override {
-        Execution[] memory executions = abi.decode(data, (Execution[]));
+    function execute(Intent memory intent, Proposal memory proposal) external override {
+        // solhint-disable-next-line custom-errors
+        require(intent.op == OpType.Swap, 'Invalid intent type');
+        SwapProposal memory swapProposal = abi.decode(proposal.data, (SwapProposal));
+        Execution[] memory executions = abi.decode(swapProposal.data, (Execution[]));
         ISettler(settler).execute(executions);
     }
 }

--- a/packages/evm/contracts/test/executors/TransferExecutorMock.sol
+++ b/packages/evm/contracts/test/executors/TransferExecutorMock.sol
@@ -5,6 +5,8 @@ pragma solidity ^0.8.20;
 import '../../interfaces/IExecutor.sol';
 import '../../utils/ERC20Helpers.sol';
 
+/* solhint-disable custom-errors */
+
 contract TransferExecutorMock is IExecutor {
     event Transferred();
 
@@ -12,10 +14,14 @@ contract TransferExecutorMock is IExecutor {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function execute(bytes memory data) external override {
-        (address[] memory tokens, uint256[] memory amounts) = abi.decode(data, (address[], uint256[]));
-        // solhint-disable-next-line custom-errors
+    function execute(Intent memory intent, Proposal memory proposal) external override {
+        require(intent.op == OpType.Swap, 'Invalid intent type');
+
+        SwapProposal memory swapProposal = abi.decode(proposal.data, (SwapProposal));
+        (address[] memory tokens, uint256[] memory amounts) = abi.decode(swapProposal.data, (address[], uint256[]));
+
         require(tokens.length == amounts.length, 'Invalid inputs');
+
         for (uint256 i = 0; i < tokens.length; i++) {
             ERC20Helpers.transfer(tokens[i], msg.sender, amounts[i]);
             emit Transferred();


### PR DESCRIPTION
The change introduced in this PR is necessary to handle cross-chain intents securely.
In a cross-chain swap, output verification doesn't occur in the same transaction in which input tokens are transferred. As a result, the data in the proposal can't be trusted, and the executor must rely on the values from the intent and the proposal instead.