### PR TITLE
Solana: Add `min_validations` to Controller

### DIFF
--- a/packages/svm/idls/controller.json
+++ b/packages/svm/idls/controller.json
@@ -142,8 +142,69 @@
         {
           "name": "admin",
           "type": "pubkey"
+        },
+        {
+          "name": "min_validations",
+          "type": "u16"
         }
       ]
+    },
+    {
+      "name": "resize_settings",
+      "discriminator": [
+        188,
+        179,
+        131,
+        221,
+        130,
+        249,
+        4,
+        231
+      ],
+      "accounts": [
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "controller_settings",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  116,
+                  114,
+                  111,
+                  108,
+                  108,
+                  101,
+                  114,
+                  45,
+                  115,
+                  101,
+                  116,
+                  116,
+                  105,
+                  110,
+                  103,
+                  115
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
     },
     {
       "name": "set_admin",
@@ -281,6 +342,67 @@
           "type": "bytes"
         }
       ]
+    },
+    {
+      "name": "set_min_validations",
+      "discriminator": [
+        178,
+        16,
+        7,
+        47,
+        149,
+        251,
+        165,
+        147
+      ],
+      "accounts": [
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "controller_settings"
+          ]
+        },
+        {
+          "name": "controller_settings",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  116,
+                  114,
+                  111,
+                  108,
+                  108,
+                  101,
+                  114,
+                  45,
+                  115,
+                  101,
+                  116,
+                  116,
+                  105,
+                  110,
+                  103,
+                  115
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "new_min_validations",
+          "type": "u16"
+        }
+      ]
     }
   ],
   "accounts": [
@@ -337,6 +459,19 @@
         132,
         94
       ]
+    },
+    {
+      "name": "SetMinValidationsEvent",
+      "discriminator": [
+        56,
+        201,
+        119,
+        139,
+        82,
+        184,
+        16,
+        153
+      ]
     }
   ],
   "errors": [
@@ -354,6 +489,11 @@
       "code": 6002,
       "name": "EntityAddressHasWrongSize",
       "msg": "Entity address can only be Solana (32 bytes) or Ethereum (20 bytes)"
+    },
+    {
+      "code": 6003,
+      "name": "MinValidationsCannotBeZero",
+      "msg": "Min validations cannot be zero"
     }
   ],
   "types": [
@@ -393,6 +533,10 @@
           {
             "name": "bump",
             "type": "u8"
+          },
+          {
+            "name": "min_validations",
+            "type": "u16"
           }
         ]
       }
@@ -449,6 +593,22 @@
           {
             "name": "new_admin",
             "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetMinValidationsEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "new_min_validations",
+            "type": "u16"
           },
           {
             "name": "timestamp",

--- a/packages/svm/programs/controller/src/errors.rs
+++ b/packages/svm/programs/controller/src/errors.rs
@@ -10,4 +10,7 @@ pub enum ControllerError {
 
     #[msg("Entity address can only be Solana (32 bytes) or Ethereum (20 bytes)")]
     EntityAddressHasWrongSize,
+
+    #[msg("Min validations cannot be zero")]
+    MinValidationsCannotBeZero,
 }

--- a/packages/svm/programs/controller/src/instructions/initialize.rs
+++ b/packages/svm/programs/controller/src/instructions/initialize.rs
@@ -20,16 +20,22 @@ pub struct Initialize<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn initialize(ctx: Context<Initialize>, admin: Pubkey) -> Result<()> {
+pub fn initialize(ctx: Context<Initialize>, admin: Pubkey, min_validations: u16) -> Result<()> {
     require_keys_eq!(
         ctx.accounts.deployer.key(),
         Pubkey::from_str(DEPLOYER_KEY).unwrap(),
         ControllerError::OnlyDeployer,
     );
 
+    require!(
+        min_validations > 0,
+        ControllerError::MinValidationsCannotBeZero
+    );
+
     let controller_settings = &mut ctx.accounts.controller_settings;
 
     controller_settings.admin = admin;
+    controller_settings.min_validations = min_validations;
     controller_settings.bump = ctx.bumps.controller_settings;
 
     Ok(())

--- a/packages/svm/programs/controller/src/instructions/mod.rs
+++ b/packages/svm/programs/controller/src/instructions/mod.rs
@@ -1,9 +1,13 @@
 pub mod close_entity_registry;
 pub mod initialize;
+pub mod resize_settings;
 pub mod set_admin;
 pub mod set_allowed_entity;
+pub mod set_min_validations;
 
 pub use close_entity_registry::*;
 pub use initialize::*;
+pub use resize_settings::*;
 pub use set_admin::*;
 pub use set_allowed_entity::*;
+pub use set_min_validations::*;

--- a/packages/svm/programs/controller/src/instructions/resize_settings.rs
+++ b/packages/svm/programs/controller/src/instructions/resize_settings.rs
@@ -1,0 +1,53 @@
+use anchor_lang::prelude::*;
+
+use crate::utils::resize_account;
+use crate::{errors::ControllerError, state::ControllerSettings};
+
+#[derive(Accounts)]
+pub struct ResizeSettings<'info> {
+    #[account(mut)]
+    pub admin: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"controller-settings"],
+        bump,
+        owner = crate::ID,
+    )]
+    /// CHECK: Seeds checked in macro, layout and admin checked in instruction body
+    pub controller_settings: UncheckedAccount<'info>,
+
+    pub system_program: Program<'info, System>,
+}
+
+fn check_settings_data(data: &[u8], expected_admin: Pubkey) -> Result<()> {
+    if !data.starts_with(&ControllerSettings::DISCRIMINATOR) {
+        return Err(ProgramError::InvalidAccountData.into());
+    }
+
+    let admin = Pubkey::new_from_array(data[8..40].try_into().unwrap());
+    require_keys_eq!(admin, expected_admin, ControllerError::OnlyAdmin);
+
+    Ok(())
+}
+
+pub fn resize_settings(ctx: Context<ResizeSettings>) -> Result<()> {
+    const EXPECTED_SETTINGS_LEN: usize = 8 + ControllerSettings::INIT_SPACE;
+    let controller_settings = &ctx.accounts.controller_settings.to_account_info();
+
+    {
+        let data = controller_settings.try_borrow_data()?;
+        check_settings_data(&data, ctx.accounts.admin.key())?;
+    }
+
+    if controller_settings.data_len() < EXPECTED_SETTINGS_LEN {
+        resize_account(
+            &ctx.accounts.admin.to_account_info(),
+            controller_settings,
+            EXPECTED_SETTINGS_LEN,
+            &ctx.accounts.system_program.to_account_info(),
+        )?;
+    }
+
+    Ok(())
+}

--- a/packages/svm/programs/controller/src/instructions/set_min_validations.rs
+++ b/packages/svm/programs/controller/src/instructions/set_min_validations.rs
@@ -1,0 +1,44 @@
+use anchor_lang::prelude::*;
+
+use crate::{errors::ControllerError, state::ControllerSettings};
+
+#[derive(Accounts)]
+pub struct SetMinValidations<'info> {
+    #[account(mut)]
+    pub admin: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"controller-settings"],
+        bump = controller_settings.bump,
+        has_one = admin @ ControllerError::OnlyAdmin
+    )]
+    pub controller_settings: Box<Account<'info, ControllerSettings>>,
+}
+
+pub fn set_min_validations(
+    ctx: Context<SetMinValidations>,
+    new_min_validations: u16,
+) -> Result<()> {
+    require!(
+        new_min_validations > 0,
+        ControllerError::MinValidationsCannotBeZero
+    );
+
+    let controller_settings = &mut ctx.accounts.controller_settings;
+
+    controller_settings.min_validations = new_min_validations;
+
+    emit!(SetMinValidationsEvent {
+        new_min_validations,
+        timestamp: Clock::get()?.unix_timestamp as u64,
+    });
+
+    Ok(())
+}
+
+#[event]
+pub struct SetMinValidationsEvent {
+    pub new_min_validations: u16,
+    pub timestamp: u64,
+}

--- a/packages/svm/programs/controller/src/lib.rs
+++ b/packages/svm/programs/controller/src/lib.rs
@@ -7,6 +7,7 @@ pub mod errors;
 pub mod instructions;
 pub mod state;
 pub mod types;
+pub mod utils;
 
 use crate::{instructions::*, types::*};
 
@@ -14,12 +15,23 @@ use crate::{instructions::*, types::*};
 pub mod controller {
     use super::*;
 
-    pub fn initialize(ctx: Context<Initialize>, admin: Pubkey) -> Result<()> {
-        instructions::initialize(ctx, admin)
+    pub fn initialize(ctx: Context<Initialize>, admin: Pubkey, min_validations: u16) -> Result<()> {
+        instructions::initialize(ctx, admin, min_validations)
+    }
+
+    pub fn resize_settings(ctx: Context<ResizeSettings>) -> Result<()> {
+        instructions::resize_settings(ctx)
     }
 
     pub fn set_admin(ctx: Context<SetAdmin>, new_admin: Pubkey) -> Result<()> {
         instructions::set_admin(ctx, new_admin)
+    }
+
+    pub fn set_min_validations(
+        ctx: Context<SetMinValidations>,
+        new_min_validations: u16,
+    ) -> Result<()> {
+        instructions::set_min_validations(ctx, new_min_validations)
     }
 
     pub fn set_allowed_entity(

--- a/packages/svm/programs/controller/src/state/controller_settings.rs
+++ b/packages/svm/programs/controller/src/state/controller_settings.rs
@@ -5,4 +5,5 @@ use anchor_lang::prelude::*;
 pub struct ControllerSettings {
     pub admin: Pubkey,
     pub bump: u8,
+    pub min_validations: u16,
 }

--- a/packages/svm/programs/controller/src/utils.rs
+++ b/packages/svm/programs/controller/src/utils.rs
@@ -1,0 +1,23 @@
+use anchor_lang::prelude::{program::invoke, *};
+
+pub fn resize_account<'info>(
+    from: &AccountInfo<'info>,
+    account: &AccountInfo<'info>,
+    new_len: usize,
+    system_program: &AccountInfo<'info>,
+) -> Result<()> {
+    let rent = Rent::get()?;
+    let needed = rent.minimum_balance(new_len);
+    let missing = needed.saturating_sub(account.lamports());
+
+    if missing > 0 {
+        invoke(
+            &system_instruction::transfer(&from.key(), &account.key(), missing),
+            &[from.clone(), account.clone(), system_program.clone()],
+        )?;
+    }
+
+    account.resize(new_len)?;
+
+    Ok(())
+}

--- a/packages/svm/programs/settler/src/instructions/create_intent.rs
+++ b/packages/svm/programs/settler/src/instructions/create_intent.rs
@@ -1,7 +1,11 @@
 use anchor_lang::prelude::*;
 
 use crate::{
-    controller::{self, accounts::EntityRegistry, types::EntityType},
+    controller::{
+        self,
+        accounts::{ControllerSettings, EntityRegistry},
+        types::EntityType,
+    },
     errors::SettlerError,
     state::Intent,
     types::{IntentEvent, OpType, TokenFee},
@@ -26,7 +30,7 @@ pub struct CreateIntent<'info> {
         seeds = [b"intent", intent_hash.as_ref()],
         bump,
         payer = solver,
-        space = Intent::total_size(data.len(), max_fees.len(), &events, min_validations)?
+        space = Intent::total_size(data.len(), max_fees.len(), &events, min_validations.max(controller_settings.min_validations))?
     )]
     // TODO: change to AccountLoader?
     // TODO: init within the handler body to save compute?
@@ -38,6 +42,13 @@ pub struct CreateIntent<'info> {
     )]
     /// This PDA must be uninitialized
     pub fulfilled_intent: SystemAccount<'info>,
+
+    #[account(
+        seeds = [b"controller-settings"],
+        bump = controller_settings.bump,
+        seeds::program = controller::ID,
+    )]
+    pub controller_settings: Box<Account<'info, ControllerSettings>>,
 
     pub system_program: Program<'info, System>,
 }
@@ -62,6 +73,7 @@ pub fn create_intent(
     // TODO: check hash
 
     let intent = &mut ctx.accounts.intent;
+    let controller_min_validations = ctx.accounts.controller_settings.min_validations;
 
     intent.op = op;
     intent.user = user;
@@ -69,7 +81,7 @@ pub fn create_intent(
     intent.hash = intent_hash;
     intent.nonce = nonce;
     intent.deadline = deadline;
-    intent.min_validations = min_validations;
+    intent.min_validations = min_validations.max(controller_min_validations);
     intent.is_final = is_final;
     intent.data = data;
     intent.max_fees = max_fees;

--- a/packages/svm/tests/controller.test.ts
+++ b/packages/svm/tests/controller.test.ts
@@ -213,7 +213,7 @@ describe('Controller', () => {
         const ix = await maliciousSdk.resizeSettings()
         const res = await makeTxSignAndSend(maliciousProvider, ix)
 
-        expect(res, 'Only admin can call this instruction')
+        expectTransactionError(res, 'Only admin can call this instruction')
       })
     })
 

--- a/packages/svm/tests/controller.test.ts
+++ b/packages/svm/tests/controller.test.ts
@@ -6,7 +6,7 @@ import { EntityType, SvmController } from '@mimicprotocol/sdk'
 import { fromWorkspace, LiteSVMProvider } from 'anchor-litesvm'
 import { expect } from 'chai'
 import fs from 'fs'
-import { LiteSVM } from 'litesvm'
+import { AccountInfoBytes, LiteSVM } from 'litesvm'
 import os from 'os'
 import path from 'path'
 
@@ -75,7 +75,7 @@ describe('Controller', () => {
       it('cannot initialize', async () => {
         const newAdmin = randomPubkey()
 
-        const ix = await maliciousSdk.initializeIx(newAdmin)
+        const ix = await maliciousSdk.initializeIx(newAdmin, 1)
         const res = await makeTxSignAndSend(maliciousProvider, ix)
 
         expectTransactionError(res, 'Only deployer can call this instruction')
@@ -83,29 +83,57 @@ describe('Controller', () => {
     })
 
     context('when caller is deployer', async () => {
-      it('should initialize', async () => {
-        const ix = await deployerSdk.initializeIx(admin.publicKey)
-        await makeTxSignAndSend(deployerProvider, ix)
+      context('when min validations are not valid', () => {
+        context('when min validations are 0', () => {
+          it('throws an error', async () => {
+            const ix = await deployerSdk.initializeIx(admin.publicKey, 0)
+            const res = await makeTxSignAndSend(deployerProvider, ix)
 
-        const settings = await program.account.controllerSettings.fetch(deployerSdk.getControllerSettingsPubkey())
-        expect(settings.admin.toString()).to.be.eq(admin.publicKey.toString())
+            expectTransactionError(res, 'Min validations cannot be zero')
+          })
+        })
+
+        context('when min validations are less than 0', () => {
+          it('throws an error', async () => {
+            try {
+              await deployerSdk.initializeIx(admin.publicKey, -1)
+            } catch (e) {
+              expect(String(e)).to.be.eq(
+                'RangeError [ERR_OUT_OF_RANGE]: The value of "value" is out of range. It must be >= 0 and <= 65535. Received -1'
+              )
+            }
+          })
+        })
       })
 
-      it('cannot call initialize again', async () => {
-        const ix = await deployerSdk.initializeIx(admin.publicKey)
-        const res = await makeTxSignAndSend(deployerProvider, ix)
+      context('when min validations are valid', async () => {
+        const minValidations = 2
 
-        expectTransactionError(res, 'already in use')
+        it('should initialize', async () => {
+          const ix = await deployerSdk.initializeIx(admin.publicKey, minValidations)
+          await makeTxSignAndSend(deployerProvider, ix)
+
+          const settings = await program.account.controllerSettings.fetch(deployerSdk.getControllerSettingsPubkey())
+          expect(settings.admin.toString()).to.be.eq(admin.publicKey.toString())
+          expect(settings.minValidations).to.be.eq(minValidations)
+        })
+
+        it('cannot call initialize again', async () => {
+          const ix = await deployerSdk.initializeIx(admin.publicKey, minValidations)
+          const res = await makeTxSignAndSend(deployerProvider, ix)
+
+          expectTransactionError(res, 'already in use')
+        })
       })
     })
   })
 
-  describe('set admin', () => {
+  describe('set_admin', () => {
     context('when caller is not admin', async () => {
       it('cannot set admin', async () => {
         const newAdmin = randomPubkey()
 
-        const ix = await maliciousSdk.setAdmin(newAdmin)
+        const ix = await maliciousSdk.setAdminIx(newAdmin)
         const res = await makeTxSignAndSend(maliciousProvider, ix)
 
         expectTransactionError(res, 'Only admin can call this instruction')
@@ -114,16 +142,161 @@ describe('Controller', () => {
 
     context('when caller is admin', async () => {
       after('reset admin to original for subsequent tests', async () => {
-        const resetIx = await otherAdminSdk.setAdmin(admin.publicKey)
+        const resetIx = await otherAdminSdk.setAdminIx(admin.publicKey)
         await makeTxSignAndSend(otherAdminProvider, resetIx)
       })
 
       it('can set admin', async () => {
-        const ix = await adminSdk.setAdmin(otherAdmin.publicKey)
+        const ix = await adminSdk.setAdminIx(otherAdmin.publicKey)
         await makeTxSignAndSend(adminProvider, ix)
 
         const settings = await program.account.controllerSettings.fetch(adminSdk.getControllerSettingsPubkey())
         expect(settings.admin.toString()).to.be.eq(otherAdmin.publicKey.toString())
+      })
+    })
+  })
+
+  describe('set_min_validations', () => {
+    context('when caller is not admin', () => {
+      it('throws an error', async () => {
+        const ix = await maliciousSdk.setMinValidationsIx(2)
+        const res = await makeTxSignAndSend(maliciousProvider, ix)
+
+        expectTransactionError(res, 'Only admin can call this instruction')
+      })
+    })
+
+    context('when caller is admin', () => {
+      context('when min validations are not valid', () => {
+        context('when min validations are zero', () => {
+          it('throws an error', async () => {
+            const ix = await adminSdk.setMinValidationsIx(0)
+            const res = await makeTxSignAndSend(adminProvider, ix)
+
+            expectTransactionError(res, 'Min validations cannot be zero')
+          })
+        })
+
+        context('when min validations are less than zero', () => {
+          it('throws an error', async () => {
+            try {
+              await adminSdk.setMinValidationsIx(-1)
+            } catch (e) {
+              expect(String(e)).to.be.eq(
+                'RangeError [ERR_OUT_OF_RANGE]: The value of "value" is out of range. It must be >= 0 and <= 65535. Received -1'
+              )
+            }
+          })
+        })
+      })
+
+      context('when min validations are valid', () => {
+        it('sets min validations', async () => {
+          const newMinValidations = 1
+
+          let settings = await program.account.controllerSettings.fetch(adminSdk.getControllerSettingsPubkey())
+          expect(settings.minValidations).to.not.be.eq(newMinValidations)
+
+          const ix = await adminSdk.setMinValidationsIx(newMinValidations)
+          await makeTxSignAndSend(adminProvider, ix)
+
+          settings = await program.account.controllerSettings.fetch(adminSdk.getControllerSettingsPubkey())
+          expect(settings.minValidations).to.be.eq(newMinValidations)
+        })
+      })
+    })
+  })
+
+  describe('resize_settings', () => {
+    context('when caller is not admin', () => {
+      it('throws an error', async () => {
+        const ix = await maliciousSdk.resizeSettings()
+        const res = await makeTxSignAndSend(maliciousProvider, ix)
+
+        expect(res, 'Only admin can call this instruction')
+      })
+    })
+
+    context('when caller is admin', () => {
+      const itIsIdempotent = () => {
+        it('is idempotent', async () => {
+          const settingsBefore = client.getAccount(adminSdk.getControllerSettingsPubkey())
+
+          const ix = await adminSdk.resizeSettings()
+          await makeTxSignAndSend(adminProvider, ix)
+
+          const settingsAfter = client.getAccount(adminSdk.getControllerSettingsPubkey())
+
+          expect(settingsBefore).to.not.be.undefined
+          expect(settingsAfter).to.not.be.undefined
+          expect(settingsAfter!.data.length).to.be.eq(settingsBefore!.data.length)
+        })
+      }
+
+      context('when settings are not correct size', () => {
+        context('when settings are larger', () => {
+          // NOTE: This is an impossible case, but we test it nevertheless just in case.
+          // Given the scenario where the settings grew larger than the minimum size for
+          // some reason, calling this instruction still does not truncate the PDA as
+          // doing that would imply potential data loss.
+
+          let controllerSettingsAccount: AccountInfoBytes
+
+          beforeEach('Mock large ControllerSettings PDA (impossible scenario)', () => {
+            const controllerSettingsKey = adminSdk.getControllerSettingsPubkey()
+            controllerSettingsAccount = client.getAccount(controllerSettingsKey)!
+
+            const mockSettings = {
+              ...controllerSettingsAccount,
+              data: Uint8Array.from(Array(1000)),
+            }
+
+            client.setAccount(adminSdk.getControllerSettingsPubkey(), mockSettings)
+          })
+
+          itIsIdempotent()
+
+          afterEach('Restore PDA', () => {
+            client.setAccount(adminSdk.getControllerSettingsPubkey(), controllerSettingsAccount)
+          })
+        })
+
+        context('when settings are smaller', () => {
+          let controllerSettingsAccount: AccountInfoBytes
+
+          beforeEach('Mock large ControllerSettings PDA (e.g. after a program upgrade)', () => {
+            const controllerSettingsKey = adminSdk.getControllerSettingsPubkey()
+            controllerSettingsAccount = client.getAccount(controllerSettingsKey)!
+
+            const mockSettings = {
+              ...controllerSettingsAccount,
+              data: controllerSettingsAccount.data.slice(0, controllerSettingsAccount.data.length - 2),
+            }
+
+            client.setAccount(adminSdk.getControllerSettingsPubkey(), mockSettings)
+          })
+
+          it('resizes settings', async () => {
+            const settingsBefore = client.getAccount(adminSdk.getControllerSettingsPubkey())
+
+            const ix = await adminSdk.resizeSettings()
+            await makeTxSignAndSend(adminProvider, ix)
+
+            const settingsAfter = client.getAccount(adminSdk.getControllerSettingsPubkey())
+
+            expect(settingsBefore).to.not.be.undefined
+            expect(settingsAfter).to.not.be.undefined
+            expect(settingsAfter!.data.length).to.be.greaterThan(settingsBefore!.data.length)
+          })
+
+          afterEach('Restore PDA', () => {
+            client.setAccount(adminSdk.getControllerSettingsPubkey(), controllerSettingsAccount)
+          })
+        })
+      })
+
+      context('when settings are correct size', () => {
+        itIsIdempotent()
       })
     })
   })
@@ -183,7 +356,7 @@ describe('Controller', () => {
       })
 
       it('should change admin for next tests', async () => {
-        const ix = await adminSdk.setAdmin(otherAdmin.publicKey)
+        const ix = await adminSdk.setAdminIx(otherAdmin.publicKey)
         await makeTxSignAndSend(adminProvider, ix)
 
         const settings = await program.account.controllerSettings.fetch(adminSdk.getControllerSettingsPubkey())
@@ -231,7 +404,7 @@ describe('Controller', () => {
 
     context('when the admin is changed and caller is new admin', async () => {
       before('change admin for next tests', async () => {
-        const ix = await adminSdk.setAdmin(otherAdmin.publicKey)
+        const ix = await adminSdk.setAdminIx(otherAdmin.publicKey)
         await makeTxSignAndSend(adminProvider, ix)
       })
 

--- a/packages/svm/tests/settler.test.ts
+++ b/packages/svm/tests/settler.test.ts
@@ -129,7 +129,7 @@ describe('Settler', () => {
 
     // Initialize Controller and add Solver to allowlist
     controllerSdk = new SvmController(provider)
-    await makeTxSignAndSend(provider, await controllerSdk.initializeIx(admin.publicKey))
+    await makeTxSignAndSend(provider, await controllerSdk.initializeIx(admin.publicKey, 1))
     await makeTxSignAndSend(provider, await controllerSdk.setAllowedEntityIx(EntityType.Solver, solver.publicKey))
   })
 

--- a/packages/svm/tests/settler.test.ts
+++ b/packages/svm/tests/settler.test.ts
@@ -86,7 +86,7 @@ import { makeTxSignAndSend, warpSeconds } from './utils'
 describe('Settler', () => {
   let client: LiteSVM
 
-  let provider: LiteSVMProvider
+  let adminProvider: LiteSVMProvider
   let maliciousProvider: LiteSVMProvider
   let solverProvider: LiteSVMProvider
 
@@ -94,7 +94,7 @@ describe('Settler', () => {
   let malicious: Keypair
   let solver: Keypair
 
-  let program: Program<Settler>
+  let settler: Program<Settler>
 
   let sdk: SvmSettler
   let maliciousSdk: SvmSettler
@@ -112,25 +112,25 @@ describe('Settler', () => {
 
     client = fromWorkspace(path.join(__dirname, '../')).withBuiltins().withPrecompiles().withSysvars()
 
-    provider = new LiteSVMProvider(client, new Wallet(admin))
+    adminProvider = new LiteSVMProvider(client, new Wallet(admin))
     maliciousProvider = new LiteSVMProvider(client, new Wallet(malicious))
     solverProvider = new LiteSVMProvider(client, new Wallet(solver))
 
-    program = new Program<Settler>(SettlerIDL as any, provider)
+    settler = new Program<Settler>(SettlerIDL as any, adminProvider)
 
-    sdk = new SvmSettler(provider)
+    sdk = new SvmSettler(adminProvider)
     maliciousSdk = new SvmSettler(maliciousProvider)
     solverSdk = new SvmSettler(solverProvider)
-    adminSdk = new SvmSettler(provider)
+    adminSdk = new SvmSettler(adminProvider)
 
-    provider.client.airdrop(admin.publicKey, toLamports(100))
-    provider.client.airdrop(malicious.publicKey, toLamports(100))
-    provider.client.airdrop(solver.publicKey, toLamports(100))
+    adminProvider.client.airdrop(admin.publicKey, toLamports(100))
+    adminProvider.client.airdrop(malicious.publicKey, toLamports(100))
+    adminProvider.client.airdrop(solver.publicKey, toLamports(100))
 
     // Initialize Controller and add Solver to allowlist
-    controllerSdk = new SvmController(provider)
-    await makeTxSignAndSend(provider, await controllerSdk.initializeIx(admin.publicKey, 1))
-    await makeTxSignAndSend(provider, await controllerSdk.setAllowedEntityIx(EntityType.Solver, solver.publicKey))
+    controllerSdk = new SvmController(adminProvider)
+    await makeTxSignAndSend(adminProvider, await controllerSdk.initializeIx(admin.publicKey, 1))
+    await makeTxSignAndSend(adminProvider, await controllerSdk.setAllowedEntityIx(EntityType.Solver, solver.publicKey))
   })
 
   beforeEach(() => {
@@ -156,16 +156,16 @@ describe('Settler', () => {
 
       it('should call initialize', async () => {
         const ix = await sdk.initializeIx(domain)
-        await makeTxSignAndSend(provider, ix)
+        await makeTxSignAndSend(adminProvider, ix)
 
-        const settings = await program.account.settlerSettings.fetch(sdk.getSettlerSettingsKey())
+        const settings = await settler.account.settlerSettings.fetch(sdk.getSettlerSettingsKey())
         expect(settings.controllerProgram.toString()).to.be.eq(ControllerIDL.address)
         expect(bytesToHex(Buffer.from(settings.eip712DomainHash))).to.be.eq(ethers.TypedDataEncoder.hashDomain(domain))
       })
 
       it('cannot call initialize again', async () => {
         const ix = await sdk.initializeIx({})
-        const res = await makeTxSignAndSend(provider, ix)
+        const res = await makeTxSignAndSend(adminProvider, ix)
 
         expectTransactionError(res, 'already in use')
       })
@@ -178,8 +178,8 @@ describe('Settler', () => {
         const itUpdatesDomainCorrectly = (testCase: string, domain: SolanaEip712Domain) => {
           it(`updates domain correctly (${testCase})`, async () => {
             const ix = await adminSdk.updateEip712DomainIx(domain)
-            const res = await makeTxSignAndSend(provider, ix)
-            const settings = await program.account.settlerSettings.fetch(adminSdk.getSettlerSettingsKey())
+            const res = await makeTxSignAndSend(adminProvider, ix)
+            const settings = await settler.account.settlerSettings.fetch(adminSdk.getSettlerSettingsKey())
             expect(res.toString()).to.not.include('FailedTransaction')
             expect(bytesToHex(Buffer.from(settings.eip712DomainHash))).to.be.eq(
               ethers.TypedDataEncoder.hashDomain(domain)
@@ -206,7 +206,7 @@ describe('Settler', () => {
       context('when domain is invalid', () => {
         const itThrowsAnError = (testCase: string, domain: SolanaEip712Domain, error: string) => {
           it(`throws an error (${testCase})`, async () => {
-            const ix = await program.methods
+            const ix = await settler.methods
               .updateEip712Domain({
                 name: null,
                 version: null,
@@ -215,7 +215,7 @@ describe('Settler', () => {
                 chainId: domain.chainId ? new BN(domain.chainId) : null,
               })
               .instruction()
-            const res = await makeTxSignAndSend(provider, ix)
+            const res = await makeTxSignAndSend(adminProvider, ix)
             expectTransactionError(res, error)
           })
         }
@@ -250,45 +250,73 @@ describe('Settler', () => {
       context('when intent data is valid', () => {
         context('when intent does not exist', () => {
           context('when creating a basic intent', () => {
-            const intentOptions: CreateIntentOptions = {
-              op: OpType.Transfer,
-              user: randomPubkey(),
-              nonce: generateNonce(),
-              deadline: '10000',
-              minValidations: 5,
-              data: TEST_DATA_HEX_1,
-              maxFees: [
-                {
-                  token: randomPubkey(),
-                  amount: '1000',
-                },
-              ],
-              events: [
-                {
-                  topic: randomHex(32).slice(2),
-                  data: randomHex(100).slice(2),
-                },
-              ],
-              isFinal: true,
+            const itWorksAsExpected = (minValidations: number) => {
+              const intentOptions: CreateIntentOptions = {
+                op: OpType.Transfer,
+                user: randomPubkey(),
+                nonce: generateNonce(),
+                deadline: '10000',
+                minValidations,
+                data: TEST_DATA_HEX_1,
+                maxFees: [
+                  {
+                    token: randomPubkey(),
+                    amount: '1000',
+                  },
+                ],
+                events: [
+                  {
+                    topic: randomHex(32).slice(2),
+                    data: randomHex(100).slice(2),
+                  },
+                ],
+                isFinal: true,
+              }
+
+              it('creates the intent with correct properties', async () => {
+                intentHash = await createTestIntent(solverSdk, solverProvider, intentOptions)
+                const intent = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
+
+                expect(intent.op).to.deep.include({ transfer: {} })
+                expect(intent.user.toString()).to.be.eq(intentOptions.user!.toString())
+                expect(intent.creator.toString()).to.be.eq(solver.publicKey.toString())
+                expect(bytesToHex(Buffer.from(intent.nonce))).to.be.eq(intentOptions.nonce)
+                expect(intent.deadline.toString()).to.be.eq(intentOptions.deadline)
+                expect(intent.minValidations).to.be.eq(
+                  Math.max(controllerMinValidations, intentOptions.minValidations ?? 0)
+                )
+                expect(intent.isFinal).to.be.true
+                expect(Buffer.from(intent.data).toString('hex')).to.be.eq(intentOptions.data)
+                expect(intent.maxFees.length).to.be.eq(1)
+                expect(intent.maxFees[0].amount.toNumber()).to.be.eq(1000)
+                expect(intent.events.length).to.be.eq(1)
+                expect(intent.validators.length).to.be.eq(0)
+                expect(Buffer.from(intent.events[0].data).toString('hex')).to.be.eq(intentOptions.events![0].data)
+              })
             }
 
-            it('creates the intent with correct properties', async () => {
-              intentHash = await createTestIntent(solverSdk, solverProvider, intentOptions)
-              const intent = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+            const controllerMinValidations = 3
 
-              expect(intent.op).to.deep.include({ transfer: {} })
-              expect(intent.user.toString()).to.be.eq(intentOptions.user!.toString())
-              expect(intent.creator.toString()).to.be.eq(solver.publicKey.toString())
-              expect(bytesToHex(Buffer.from(intent.nonce))).to.be.eq(intentOptions.nonce)
-              expect(intent.deadline.toString()).to.be.eq(intentOptions.deadline)
-              expect(intent.minValidations).to.be.eq(intentOptions.minValidations)
-              expect(intent.isFinal).to.be.true
-              expect(Buffer.from(intent.data).toString('hex')).to.be.eq(intentOptions.data)
-              expect(intent.maxFees.length).to.be.eq(1)
-              expect(intent.maxFees[0].amount.toNumber()).to.be.eq(1000)
-              expect(intent.events.length).to.be.eq(1)
-              expect(intent.validators.length).to.be.eq(0)
-              expect(Buffer.from(intent.events[0].data).toString('hex')).to.be.eq(intentOptions.events![0].data)
+            before('Set Controller min validations to 3 for tests', async () => {
+              const ix = await controllerSdk.setMinValidationsIx(controllerMinValidations)
+              await makeTxSignAndSend(adminProvider, ix)
+            })
+
+            context("when intent minValidations are less than Controller's", () => {
+              itWorksAsExpected(controllerMinValidations - 1)
+            })
+
+            context("when intent minValidations are more than Controller's", () => {
+              itWorksAsExpected(controllerMinValidations + 1)
+            })
+
+            context("when intent minValidations are equal to Controller's", () => {
+              itWorksAsExpected(controllerMinValidations)
+            })
+
+            after('Restore Controller min validations to 1 for future tests', async () => {
+              const ix = await controllerSdk.setMinValidationsIx(1)
+              await makeTxSignAndSend(adminProvider, ix)
             })
           })
 
@@ -300,7 +328,7 @@ describe('Settler', () => {
 
             it('creates the intent', async () => {
               intentHash = await createTestIntent(solverSdk, solverProvider, intentOptions)
-              const intent = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+              const intent = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
               expect(intent.op).to.deep.include({ transfer: {} })
               expect(Buffer.from(intent.data).toString('hex')).to.be.eq(EMPTY_DATA_HEX)
               expect(intent.isFinal).to.be.true
@@ -315,7 +343,7 @@ describe('Settler', () => {
 
             it('creates the intent', async () => {
               intentHash = await createTestIntent(solverSdk, solverProvider, intentOptions)
-              const intent = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+              const intent = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
               expect(intent.events.length).to.be.eq(0)
             })
           })
@@ -328,7 +356,7 @@ describe('Settler', () => {
 
             it('creates the intent', async () => {
               intentHash = await createTestIntent(solverSdk, solverProvider, intentOptions)
-              const intent = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+              const intent = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
               expect(intent.isFinal).to.be.true
             })
           })
@@ -341,7 +369,7 @@ describe('Settler', () => {
 
             it('creates the intent', async () => {
               intentHash = await createTestIntent(solverSdk, solverProvider, intentOptions)
-              const intent = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+              const intent = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
               expect(intent.isFinal).to.be.false
             })
           })
@@ -357,7 +385,7 @@ describe('Settler', () => {
               client.setAccount(fulfilledIntent, {
                 executable: false,
                 lamports: 1002240,
-                owner: program.programId,
+                owner: settler.programId,
                 data: Buffer.from('595168911b9267f7' + '010000000000000000', 'hex'),
               })
             })
@@ -411,10 +439,10 @@ describe('Settler', () => {
             }))
             const intentKey = PublicKey.findProgramAddressSync(
               [Buffer.from('intent'), hexToBytes(intentHash)],
-              program.programId
+              settler.programId
             )[0]
 
-            ix = await program.methods
+            ix = await settler.methods
               .createIntent(
                 intentHashParam,
                 dataArray,
@@ -503,7 +531,7 @@ describe('Settler', () => {
                   const ix = await solverSdk.extendIntentIx(intentHash, extendParams, false)
                   await makeTxSignAndSend(solverProvider, ix)
 
-                  const intent = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+                  const intent = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
                   expect(Buffer.from(intent.data).toString('hex')).to.be.eq(
                     `${DEFAULT_DATA_HEX}${extendParams.moreDataHex}`
                   )
@@ -528,7 +556,7 @@ describe('Settler', () => {
                   const ix = await solverSdk.extendIntentIx(intentHash, extendParams, false)
                   await makeTxSignAndSend(solverProvider, ix)
 
-                  const intent = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+                  const intent = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
                   expect(intent.maxFees.length).to.be.eq(2)
                   expect(intent.maxFees[0].amount.toNumber()).to.be.eq(DEFAULT_MAX_FEE)
                   expect(intent.maxFees[1].token.toString()).to.be.eq(extendParams.moreMaxFees![0].token.toString())
@@ -553,7 +581,7 @@ describe('Settler', () => {
                   const ix = await solverSdk.extendIntentIx(intentHash, extendParams, false)
                   await makeTxSignAndSend(solverProvider, ix)
 
-                  const intent = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+                  const intent = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
                   expect(intent.events.length).to.be.eq(2)
                   expect(Buffer.from(intent.events[1].topic).toString('hex')).to.be.eq(
                     extendParams.moreEventsHex![0].topic
@@ -591,7 +619,7 @@ describe('Settler', () => {
                   const ix = await solverSdk.extendIntentIx(intentHash, extendParams, false)
                   await makeTxSignAndSend(solverProvider, ix)
 
-                  const intent = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+                  const intent = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
                   expect(Buffer.from(intent.data).toString('hex')).to.be.eq(`${TEST_DATA_HEX_1}${TEST_DATA_HEX_2}`)
                   expect(intent.maxFees.length).to.be.eq(2)
                   expect(intent.maxFees[1].amount.toString()).to.be.eq(extendParams.moreMaxFees![0].amount)
@@ -641,7 +669,7 @@ describe('Settler', () => {
                     for (let i = 0; i < loops; i++) {
                       const ix = await solverSdk.extendIntentIx(intentHash, extendParams, false)
                       const res = await makeTxSignAndSend(solverProvider, ix)
-                      expect(res.toString()).to.include(`Program ${program.programId} success`)
+                      expect(res.toString()).to.include(`Program ${settler.programId} success`)
                       client.expireBlockhash()
                     }
                   })
@@ -658,7 +686,7 @@ describe('Settler', () => {
                 })
 
                 it('extended the intent fields as expected', async () => {
-                  const intent = await program.account.intent.fetch(intentKey)
+                  const intent = await settler.account.intent.fetch(intentKey)
                   const intentAcc = client.getAccount(intentKey)
                   expect(intent.data.length).to.be.eq(5000)
                   expect(intent.maxFees.length).to.be.eq(55)
@@ -692,7 +720,7 @@ describe('Settler', () => {
                 })
 
                 it('extended the intent as expected', async () => {
-                  const intent = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+                  const intent = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
                   expect(Buffer.from(intent.data).toString('hex')).to.be.eq(
                     `${TEST_DATA_HEX_1}${extendParams1.moreDataHex}${extendParams2.moreDataHex}`
                   )
@@ -713,7 +741,7 @@ describe('Settler', () => {
                 const ix = await solverSdk.extendIntentIx(intentHash, extendParams, true)
                 await makeTxSignAndSend(solverProvider, ix)
 
-                const intent = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+                const intent = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
                 expect(intent.isFinal).to.be.true
               })
             })
@@ -731,7 +759,7 @@ describe('Settler', () => {
                 const ix = await solverSdk.extendIntentIx(intentHash, extendParams, true)
                 await makeTxSignAndSend(solverProvider, ix)
 
-                const intent = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+                const intent = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
                 expect(Buffer.from(intent.data).toString('hex')).to.be.eq(
                   `${TEST_DATA_HEX_2}${extendParams.moreDataHex}`
                 )
@@ -764,7 +792,7 @@ describe('Settler', () => {
 
         it('throws an error', async () => {
           const ix = await sdk.extendIntentIx(intentHash, extendParams, false)
-          const res = await makeTxSignAndSend(provider, ix)
+          const res = await makeTxSignAndSend(adminProvider, ix)
 
           expectTransactionError(res, `AccountNotInitialized`)
         })
@@ -797,22 +825,22 @@ describe('Settler', () => {
               const deadline = getCurrentTimestamp(client, STALE_CLAIM_DELAY)
               intentHash = await createTestIntent(solverSdk, solverProvider, { deadline, isFinal: true })
 
-              warpSeconds(provider, STALE_CLAIM_DELAY_PLUS_ONE)
+              warpSeconds(adminProvider, STALE_CLAIM_DELAY_PLUS_ONE)
             })
 
             it('claims the stale intent', async () => {
-              const intentBefore = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
-              const intentBalanceBefore = Number(provider.client.getBalance(sdk.getIntentKey(intentHash))) || 0
-              const intentCreatorBalanceBefore = Number(provider.client.getBalance(intentBefore.creator)) || 0
+              const intentBefore = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
+              const intentBalanceBefore = Number(adminProvider.client.getBalance(sdk.getIntentKey(intentHash))) || 0
+              const intentCreatorBalanceBefore = Number(adminProvider.client.getBalance(intentBefore.creator)) || 0
 
               const ix = await solverSdk.claimStaleIntentIx(intentHash)
               await makeTxSignAndSend(solverProvider, ix)
 
-              const intentBalanceAfter = Number(provider.client.getBalance(sdk.getIntentKey(intentHash))) || 0
-              const intentCreatorBalanceAfter = Number(provider.client.getBalance(intentBefore.creator)) || 0
+              const intentBalanceAfter = Number(adminProvider.client.getBalance(sdk.getIntentKey(intentHash))) || 0
+              const intentCreatorBalanceAfter = Number(adminProvider.client.getBalance(intentBefore.creator)) || 0
 
               try {
-                await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+                await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
                 expect.fail('Intent account should be closed')
               } catch (error: any) {
                 expect(error.message).to.include(`Account does not exist`)
@@ -837,22 +865,22 @@ describe('Settler', () => {
               const deadline = getCurrentTimestamp(client, STALE_CLAIM_DELAY)
               intentHash = await createTestIntent(solverSdk, solverProvider, { deadline, isFinal: false })
 
-              warpSeconds(provider, STALE_CLAIM_DELAY_PLUS_ONE)
+              warpSeconds(adminProvider, STALE_CLAIM_DELAY_PLUS_ONE)
             })
 
             it('claims the stale intent', async () => {
-              const intentBefore = await program.account.intent.fetch(sdk.getIntentKey(intentHash))
-              const intentBalanceBefore = Number(provider.client.getBalance(sdk.getIntentKey(intentHash))) || 0
-              const intentCreatorBalanceBefore = Number(provider.client.getBalance(intentBefore.creator)) || 0
+              const intentBefore = await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
+              const intentBalanceBefore = Number(adminProvider.client.getBalance(sdk.getIntentKey(intentHash))) || 0
+              const intentCreatorBalanceBefore = Number(adminProvider.client.getBalance(intentBefore.creator)) || 0
 
               const ix = await solverSdk.claimStaleIntentIx(intentHash)
               await makeTxSignAndSend(solverProvider, ix)
 
-              const intentBalanceAfter = Number(provider.client.getBalance(sdk.getIntentKey(intentHash))) || 0
-              const intentCreatorBalanceAfter = Number(provider.client.getBalance(intentBefore.creator)) || 0
+              const intentBalanceAfter = Number(adminProvider.client.getBalance(sdk.getIntentKey(intentHash))) || 0
+              const intentCreatorBalanceAfter = Number(adminProvider.client.getBalance(intentBefore.creator)) || 0
 
               try {
-                await program.account.intent.fetch(sdk.getIntentKey(intentHash))
+                await settler.account.intent.fetch(sdk.getIntentKey(intentHash))
                 expect.fail('Intent account should be closed')
               } catch (error: any) {
                 expect(error.message).to.include(`Account does not exist`)
@@ -878,7 +906,7 @@ describe('Settler', () => {
             beforeEach('create intent and warp time', async () => {
               const deadline = getCurrentTimestamp(client, LONG_DEADLINE)
               intentHash = await createTestIntent(solverSdk, solverProvider, { deadline })
-              warpSeconds(provider, WARP_TIME_SHORT)
+              warpSeconds(adminProvider, WARP_TIME_SHORT)
             })
 
             it('throws an error', async () => {
@@ -892,7 +920,7 @@ describe('Settler', () => {
             beforeEach('create intent and warp time', async () => {
               const deadline = getCurrentTimestamp(client, MEDIUM_DEADLINE)
               intentHash = await createTestIntent(solverSdk, solverProvider, { deadline })
-              warpSeconds(provider, MEDIUM_DEADLINE)
+              warpSeconds(adminProvider, MEDIUM_DEADLINE)
             })
 
             it('throws an error', async () => {
@@ -921,7 +949,7 @@ describe('Settler', () => {
       beforeEach('create intent and warp time', async () => {
         const deadline = getCurrentTimestamp(client, EXPIRATION_TEST_DELAY)
         intentHash = await createTestIntent(solverSdk, solverProvider, { deadline })
-        warpSeconds(provider, EXPIRATION_TEST_DELAY_PLUS_ONE)
+        warpSeconds(adminProvider, EXPIRATION_TEST_DELAY_PLUS_ONE)
       })
 
       it('throws an error', async () => {
@@ -968,7 +996,7 @@ describe('Settler', () => {
               it('creates the proposal', async () => {
                 await createProposalFromParams()
 
-                const proposal = await program.account.proposal.fetch(
+                const proposal = await settler.account.proposal.fetch(
                   sdk.getProposalKey(params.intentHash, solver.publicKey)
                 )
                 expect(proposal.intent.toString()).to.be.eq(sdk.getIntentKey(params.intentHash).toString())
@@ -1010,7 +1038,7 @@ describe('Settler', () => {
               it('creates the proposal with multiple instructions', async () => {
                 await createProposalFromParams()
 
-                const proposal = await program.account.proposal.fetch(
+                const proposal = await settler.account.proposal.fetch(
                   sdk.getProposalKey(params.intentHash, solver.publicKey)
                 )
                 expect(proposal.instructions.length).to.be.eq(2)
@@ -1044,7 +1072,7 @@ describe('Settler', () => {
               it('creates the proposal with empty instructions', async () => {
                 await createProposalFromParams()
 
-                const proposal = await program.account.proposal.fetch(
+                const proposal = await settler.account.proposal.fetch(
                   sdk.getProposalKey(params.intentHash, solver.publicKey)
                 )
                 expect(proposal.instructions.length).to.be.eq(0)
@@ -1077,7 +1105,7 @@ describe('Settler', () => {
               it('creates proposal with correct fees', async () => {
                 await createProposalFromParams()
 
-                const proposal = await program.account.proposal.fetch(
+                const proposal = await settler.account.proposal.fetch(
                   sdk.getProposalKey(params.intentHash, solver.publicKey)
                 )
                 expect(proposal.fees.length).to.be.eq(2)
@@ -1115,7 +1143,7 @@ describe('Settler', () => {
                 beforeEach('create intent and proposal params with deadline exceeding intent', async () => {
                   const intentHash = await createValidatedIntent(solverSdk, solverProvider, client)
                   const intentDeadline = Number(
-                    (await program.account.intent.fetch(sdk.getIntentKey(intentHash))).deadline
+                    (await settler.account.intent.fetch(sdk.getIntentKey(intentHash))).deadline
                   )
 
                   params = await createProposalParams(solverSdk, solverProvider, client, {
@@ -1188,7 +1216,7 @@ describe('Settler', () => {
                 deadline: intentDeadline,
               })
 
-              warpSeconds(provider, Number(intentDeadline) + 10)
+              warpSeconds(adminProvider, Number(intentDeadline) + 10)
 
               params = await createProposalParams(solverSdk, solverProvider, client, { intentHash })
             })
@@ -1226,7 +1254,7 @@ describe('Settler', () => {
               client.setAccount(fulfilledIntent, {
                 executable: false,
                 lamports: 1002240,
-                owner: program.programId,
+                owner: settler.programId,
                 data: Buffer.from('595168911b9267f7' + '010000000000000000', 'hex'),
               })
 
@@ -1316,7 +1344,7 @@ describe('Settler', () => {
                   const ix = await solverSdk.addInstructionsToProposalIx(intentHash, moreInstructions, false)
                   await makeTxSignAndSend(solverProvider, ix)
 
-                  const proposal = await program.account.proposal.fetch(
+                  const proposal = await settler.account.proposal.fetch(
                     sdk.getProposalKey(intentHash, solver.publicKey)
                   )
                   expect(proposal.instructions.length).to.be.eq(2)
@@ -1349,7 +1377,7 @@ describe('Settler', () => {
                   const ix = await solverSdk.addInstructionsToProposalIx(intentHash, moreInstructions, false)
                   await makeTxSignAndSend(solverProvider, ix)
 
-                  const proposal = await program.account.proposal.fetch(
+                  const proposal = await settler.account.proposal.fetch(
                     sdk.getProposalKey(intentHash, solver.publicKey)
                   )
                   expect(proposal.instructions.length).to.be.eq(3)
@@ -1370,7 +1398,7 @@ describe('Settler', () => {
                   const ix = await solverSdk.addInstructionsToProposalIx(intentHash, moreInstructions, false)
                   await makeTxSignAndSend(solverProvider, ix)
 
-                  const proposal = await program.account.proposal.fetch(
+                  const proposal = await settler.account.proposal.fetch(
                     sdk.getProposalKey(intentHash, solver.publicKey)
                   )
                   expect(proposal.isFinal).to.be.false
@@ -1398,7 +1426,7 @@ describe('Settler', () => {
                   const ix2 = await solverSdk.addInstructionsToProposalIx(intentHash, moreInstructions2, false)
                   await makeTxSignAndSend(solverProvider, ix2)
 
-                  const proposal = await program.account.proposal.fetch(
+                  const proposal = await settler.account.proposal.fetch(
                     sdk.getProposalKey(intentHash, solver.publicKey)
                   )
                   expect(proposal.instructions.length).to.be.eq(3)
@@ -1421,7 +1449,7 @@ describe('Settler', () => {
                 const ix = await solverSdk.addInstructionsToProposalIx(intentHash, moreInstructions, true)
                 await makeTxSignAndSend(solverProvider, ix)
 
-                const proposal = await program.account.proposal.fetch(sdk.getProposalKey(intentHash, solver.publicKey))
+                const proposal = await settler.account.proposal.fetch(sdk.getProposalKey(intentHash, solver.publicKey))
                 expect(proposal.isFinal).to.be.true
                 expect(proposal.instructions.length).to.be.eq(2)
               })
@@ -1486,7 +1514,7 @@ describe('Settler', () => {
       })
 
       it('throws an error', async () => {
-        const ix = await program.methods
+        const ix = await settler.methods
           .addInstructionsToProposal([], true)
           .accountsPartial({
             creator: malicious.publicKey,
@@ -1528,22 +1556,22 @@ describe('Settler', () => {
               proposalParams: { deadline: getCurrentTimestamp(client, STALE_CLAIM_DELAY) },
             })
             proposalKey = solverSdk.getProposalKey(intentHash)
-            warpSeconds(provider, STALE_CLAIM_DELAY_PLUS_ONE)
+            warpSeconds(adminProvider, STALE_CLAIM_DELAY_PLUS_ONE)
           })
 
           it('claims the stale proposal', async () => {
-            const proposalBefore = await program.account.proposal.fetch(proposalKey)
-            const proposalBalanceBefore = Number(provider.client.getBalance(proposalKey)) || 0
-            const proposalCreatorBalanceBefore = Number(provider.client.getBalance(proposalBefore.creator)) || 0
+            const proposalBefore = await settler.account.proposal.fetch(proposalKey)
+            const proposalBalanceBefore = Number(adminProvider.client.getBalance(proposalKey)) || 0
+            const proposalCreatorBalanceBefore = Number(adminProvider.client.getBalance(proposalBefore.creator)) || 0
 
             const ix = await solverSdk.claimStaleProposalIx(intentHash)
             await makeTxSignAndSend(solverProvider, ix)
 
-            const proposalBalanceAfter = Number(provider.client.getBalance(proposalKey)) || 0
-            const proposalCreatorBalanceAfter = Number(provider.client.getBalance(proposalBefore.creator)) || 0
+            const proposalBalanceAfter = Number(adminProvider.client.getBalance(proposalKey)) || 0
+            const proposalCreatorBalanceAfter = Number(adminProvider.client.getBalance(proposalBefore.creator)) || 0
 
             try {
-              await program.account.proposal.fetch(proposalKey)
+              await settler.account.proposal.fetch(proposalKey)
               expect.fail('Proposal account should be closed')
             } catch (error: any) {
               expect(error.message).to.include(`Account does not exist`)
@@ -1570,7 +1598,7 @@ describe('Settler', () => {
               intentHash = await createTestProposal({
                 proposalParams: { deadline: getCurrentTimestamp(client, LONG_DEADLINE) },
               })
-              warpSeconds(provider, WARP_TIME_SHORT)
+              warpSeconds(adminProvider, WARP_TIME_SHORT)
             })
 
             itThrowsAnError('Proposal not yet expired')
@@ -1581,7 +1609,7 @@ describe('Settler', () => {
               intentHash = await createTestProposal({
                 proposalParams: { deadline: getCurrentTimestamp(client, SHORT_DEADLINE) },
               })
-              warpSeconds(provider, WARP_TIME_SHORT)
+              warpSeconds(adminProvider, WARP_TIME_SHORT)
             })
 
             itThrowsAnError('Proposal not yet expired')
@@ -1603,11 +1631,11 @@ describe('Settler', () => {
         intentHash = await createTestProposal({
           proposalParams: { deadline: getCurrentTimestamp(client, STALE_CLAIM_DELAY) },
         })
-        warpSeconds(provider, STALE_CLAIM_DELAY_PLUS_ONE)
+        warpSeconds(adminProvider, STALE_CLAIM_DELAY_PLUS_ONE)
       })
 
       it('throws an error', async () => {
-        const ix = await program.methods
+        const ix = await settler.methods
           .claimStaleProposal()
           .accountsPartial({
             creator: malicious.publicKey,
@@ -1624,7 +1652,7 @@ describe('Settler', () => {
   describe('add_validator_sigs', () => {
     const createAllowlistedValidator = async () => {
       const validator = ethers.Wallet.createRandom()
-      await createAllowlistedEntity(controllerSdk, provider, EntityType.Validator, hexToBytes(validator.address))
+      await createAllowlistedEntity(controllerSdk, adminProvider, EntityType.Validator, hexToBytes(validator.address))
       return validator
     }
 
@@ -1646,7 +1674,7 @@ describe('Settler', () => {
       const validatorEthAddress = hexToBytes(ethValidator.address)
       const eip712Preimage = new ValidatorSigner().getIntentMessage({
         hash,
-        settler: program.programId.toString(),
+        settler: settler.programId.toString(),
         chainId: Chains.Solana,
       })
 
@@ -1658,7 +1686,7 @@ describe('Settler', () => {
         ...secp256k1IxOptions,
       })
 
-      const ix = await program.methods
+      const ix = await settler.methods
         .addValidatorSig()
         .accountsPartial({
           solver: solverSdk.getSignerKey(),
@@ -1690,7 +1718,7 @@ describe('Settler', () => {
         ...SETTLER_EIP712_DOMAIN,
         chainId: Chains.Solana,
       })
-      await makeTxSignAndSend(provider, ix)
+      await makeTxSignAndSend(adminProvider, ix)
     })
 
     context('when caller is whitelisted solver', () => {
@@ -1707,9 +1735,9 @@ describe('Settler', () => {
                   })
 
                   it('should add validator to intent validators array', async () => {
-                    const intentBefore = await program.account.intent.fetch(solverSdk.getIntentKey(intentHash))
+                    const intentBefore = await settler.account.intent.fetch(solverSdk.getIntentKey(intentHash))
                     await makeTxSignAndSend(solverProvider, ...ixs)
-                    const intentAfter = await program.account.intent.fetch(solverSdk.getIntentKey(intentHash))
+                    const intentAfter = await settler.account.intent.fetch(solverSdk.getIntentKey(intentHash))
 
                     expect(intentBefore.validators.length).to.be.eq(0)
                     expect(intentAfter.validators.length).to.be.eq(1)
@@ -1721,7 +1749,7 @@ describe('Settler', () => {
                     ixs = await createSigAndIxs()
                     const res = await makeTxSignAndSend(solverProvider, ...ixs)
 
-                    const intentAfter = await program.account.intent.fetch(solverSdk.getIntentKey(intentHash))
+                    const intentAfter = await settler.account.intent.fetch(solverSdk.getIntentKey(intentHash))
 
                     expect(res.toString()).to.not.include('FailedTransactionMetadata')
                     expect(intentAfter.validators.length).to.be.eq(1)
@@ -1748,9 +1776,9 @@ describe('Settler', () => {
                       const validator = validators[i]
                       const ixs = sigIxs[i]
 
-                      const intentBefore = await program.account.intent.fetch(solverSdk.getIntentKey(intentHash))
+                      const intentBefore = await settler.account.intent.fetch(solverSdk.getIntentKey(intentHash))
                       await makeTxSignAndSend(solverProvider, ...ixs)
-                      const intentAfter = await program.account.intent.fetch(solverSdk.getIntentKey(intentHash))
+                      const intentAfter = await settler.account.intent.fetch(solverSdk.getIntentKey(intentHash))
 
                       expect(intentBefore.validators.length).to.be.eq(i)
                       expect(intentAfter.validators.length).to.be.eq(i + 1)
@@ -1768,7 +1796,7 @@ describe('Settler', () => {
                   intentHash = await createTestIntent(solverSdk, solverProvider)
                   ixs = await createSigAndIxs()
                   const ix = await adminSdk.updateEip712DomainIx({ name: 'Other Domain' })
-                  await makeTxSignAndSend(provider, ix)
+                  await makeTxSignAndSend(adminProvider, ix)
                 })
 
                 after(async () => {
@@ -1777,7 +1805,7 @@ describe('Settler', () => {
                     ...SETTLER_EIP712_DOMAIN,
                     chainId: Chains.Solana,
                   })
-                  await makeTxSignAndSend(provider, ix)
+                  await makeTxSignAndSend(adminProvider, ix)
                 })
 
                 itThrowsAnError('SigVerificationFailedIncorrectMessage')
@@ -1865,9 +1893,9 @@ describe('Settler', () => {
                   })
 
                   it('should not add the validator', async () => {
-                    const intentBefore = await program.account.intent.fetch(solverSdk.getIntentKey(intentHash))
+                    const intentBefore = await settler.account.intent.fetch(solverSdk.getIntentKey(intentHash))
                     const res = await makeTxSignAndSend(solverProvider, ...ixs)
-                    const intentAfter = await program.account.intent.fetch(solverSdk.getIntentKey(intentHash))
+                    const intentAfter = await settler.account.intent.fetch(solverSdk.getIntentKey(intentHash))
 
                     expect(res.toString()).to.not.include('FailedTransactionMetadata')
                     expect(intentBefore.validators.length).to.be.eq(1)
@@ -1911,7 +1939,7 @@ describe('Settler', () => {
                 client.setAccount(fulfilledIntent, {
                   executable: false,
                   lamports: 1002240,
-                  owner: program.programId,
+                  owner: settler.programId,
                   data: Buffer.from('595168911b9267f7' + '010000000000000000', 'hex'),
                 })
 
@@ -1944,11 +1972,11 @@ describe('Settler', () => {
         validator = ethers.Wallet.createRandom()
         ixs = await createSigAndIxs()
 
-        await removeEntityFromAllowlist(controllerSdk, provider, EntityType.Solver, solver.publicKey)
+        await removeEntityFromAllowlist(controllerSdk, adminProvider, EntityType.Solver, solver.publicKey)
       })
 
       after('re-whitelist solver', async () => {
-        await createAllowlistedEntity(controllerSdk, provider, EntityType.Solver, solver.publicKey)
+        await createAllowlistedEntity(controllerSdk, adminProvider, EntityType.Solver, solver.publicKey)
       })
 
       itThrowsAnError('Program log: AnchorError caused by account: solver_registry. Error Code: AccountNotInitialized')
@@ -1958,7 +1986,7 @@ describe('Settler', () => {
   describe('add_axia_sig', () => {
     const createAllowlistedAxia = async () => {
       const axia = ethers.Wallet.createRandom()
-      await createAllowlistedEntity(controllerSdk, provider, EntityType.Axia, hexToBytes(axia.address))
+      await createAllowlistedEntity(controllerSdk, adminProvider, EntityType.Axia, hexToBytes(axia.address))
       return axia
     }
 
@@ -1979,14 +2007,14 @@ describe('Settler', () => {
         axiaRegistry: Address
       }> = {}
     ): Promise<TransactionInstruction[]> => {
-      const proposal = await program.account.proposal.fetch(proposalKeyOverride)
-      const intent = await program.account.intent.fetch(proposal.intent)
+      const proposal = await settler.account.proposal.fetch(proposalKeyOverride)
+      const intent = await settler.account.intent.fetch(proposal.intent)
 
       const { signature, recoveryId } = await createAxiaSignature(intent.hash, proposal, ethAxia)
 
       const eip712Preimage = new ProposalSigner().getMessage(
         solverSdk.anchorProposalToEip712Proposal(proposal, intent.hash),
-        { chainId: Chains.Solana, address: program.programId.toString() }
+        { chainId: Chains.Solana, address: settler.programId.toString() }
       )
 
       const secp256k1Ix = Secp256k1Program.createInstructionWithEthAddress({
@@ -1997,7 +2025,7 @@ describe('Settler', () => {
         ...secp256k1IxOptions,
       })
 
-      const ix = await program.methods
+      const ix = await settler.methods
         .addAxiaSig()
         .accountsPartial({
           solver: solverSdk.getSignerKey(),
@@ -2029,7 +2057,7 @@ describe('Settler', () => {
         ...SETTLER_EIP712_DOMAIN,
         chainId: Chains.Solana,
       })
-      await makeTxSignAndSend(provider, ix)
+      await makeTxSignAndSend(adminProvider, ix)
     })
 
     context('when caller is whitelisted solver', () => {
@@ -2046,12 +2074,12 @@ describe('Settler', () => {
                   })
 
                   it('should sign the proposal', async () => {
-                    let proposal = await program.account.proposal.fetch(proposalKey)
+                    let proposal = await settler.account.proposal.fetch(proposalKey)
                     expect(proposal.isSigned).to.be.false
 
                     await makeTxSignAndSend(solverProvider, ...ixs)
 
-                    proposal = await program.account.proposal.fetch(proposalKey)
+                    proposal = await settler.account.proposal.fetch(proposalKey)
                     expect(proposal.isSigned).to.be.true
                   })
                 })
@@ -2065,12 +2093,12 @@ describe('Settler', () => {
                   })
 
                   it('should not sign the proposal twice (idempotent ix)', async () => {
-                    let proposal = await program.account.proposal.fetch(proposalKey)
+                    let proposal = await settler.account.proposal.fetch(proposalKey)
                     expect(proposal.isSigned).to.be.true
 
                     const res = await makeTxSignAndSend(solverProvider, ...ixs)
 
-                    proposal = await program.account.proposal.fetch(proposalKey)
+                    proposal = await settler.account.proposal.fetch(proposalKey)
                     expect(proposal.isSigned).to.be.true
                     expect(res.toString()).to.not.include('FailedTransactionMetadata')
                   })
@@ -2086,7 +2114,7 @@ describe('Settler', () => {
                       proposal: await createTestProposal(),
                     })
                     const ix = await adminSdk.updateEip712DomainIx({ name: 'Other Domain' })
-                    await makeTxSignAndSend(provider, ix)
+                    await makeTxSignAndSend(adminProvider, ix)
                   })
 
                   after(async () => {
@@ -2095,7 +2123,7 @@ describe('Settler', () => {
                       ...SETTLER_EIP712_DOMAIN,
                       chainId: Chains.Solana,
                     })
-                    await makeTxSignAndSend(provider, ix)
+                    await makeTxSignAndSend(adminProvider, ix)
                   })
 
                   itThrowsAnError('SigVerificationFailedIncorrectMessage')
@@ -2132,7 +2160,7 @@ describe('Settler', () => {
                     const validator = ethers.Wallet.createRandom()
                     await createAllowlistedEntity(
                       controllerSdk,
-                      provider,
+                      adminProvider,
                       EntityType.Validator,
                       hexToBytes(validator.address)
                     )
@@ -2195,7 +2223,7 @@ describe('Settler', () => {
                     proposalParams: { isFinal: true, deadline: getCurrentTimestamp(client, SHORT_DEADLINE) },
                   })
                   ixs = await createSigAndIxs()
-                  warpSeconds(provider, WARP_TIME_LONG)
+                  warpSeconds(adminProvider, WARP_TIME_LONG)
                 })
 
                 itThrowsAnError('ProposalIsExpired')
@@ -2207,7 +2235,7 @@ describe('Settler', () => {
                     proposalParams: { isFinal: true, deadline: getCurrentTimestamp(client, SHORT_DEADLINE) },
                   })
                   ixs = await createSigAndIxs()
-                  warpSeconds(provider, WARP_TIME_SHORT)
+                  warpSeconds(adminProvider, WARP_TIME_SHORT)
                 })
 
                 itThrowsAnError('ProposalIsExpired')
@@ -2243,7 +2271,7 @@ describe('Settler', () => {
         before('create objects and de-whitelist axia', async () => {
           proposalKey = await createTestProposal()
           ixs = await createSigAndIxs()
-          await removeEntityFromAllowlist(controllerSdk, provider, EntityType.Axia, hexToBytes(axia.address))
+          await removeEntityFromAllowlist(controllerSdk, adminProvider, EntityType.Axia, hexToBytes(axia.address))
         })
 
         itThrowsAnError('AnchorError caused by account: axia_registry. Error Code: AccountNotInitialized')
@@ -2254,11 +2282,11 @@ describe('Settler', () => {
       before('create objects and de-whitelist solver', async () => {
         proposalKey = await createTestProposal()
         ixs = await createSigAndIxs()
-        await removeEntityFromAllowlist(controllerSdk, provider, EntityType.Solver, solver.publicKey)
+        await removeEntityFromAllowlist(controllerSdk, adminProvider, EntityType.Solver, solver.publicKey)
       })
 
       after('re-whitelist solver', async () => {
-        await createAllowlistedEntity(controllerSdk, provider, EntityType.Solver, solver.publicKey)
+        await createAllowlistedEntity(controllerSdk, adminProvider, EntityType.Solver, solver.publicKey)
       })
 
       itThrowsAnError('AnchorError caused by account: solver_registry. Error Code: AccountNotInitialized')


### PR DESCRIPTION
Adds `min_validations` to Controller's global state, following EVM implementation.
This implied a change in the Controller's state PDAs, two new instructions, and a small logic change in the Settler.

**Note**: Tests will fail until SDK version is bumped.

---

# Changes

## Controller

### State
Adds `min_validations: u16` to `controller_settings`.
This field is added after all existing fields to not break the already deployed program. Eventually, if we take down this program and deploy another one, we can rearrange the fields to have `bump` be the last one.

### Instructions

#### `initialize`
Adds `min_validations: u16` as a required parameter to set it upon initialization, with a `> 0` constraint.

#### **New instruction**: `set_min_validations`
This is an admin-only instruction that lets admins update the `min_validations` field on `ControllerSettings`, with a `> 0` constraint.

#### **New instruction**: `resize_settings`
This is an admin-only instruction that lets admins resize existing `ControllerSettings` PDAs.
As the settings PDA is created using the minimum `INIT_SPACE` on initialization (when calling `initialize`), adding new fields requires a reallocation.

**A note on live programs and existing PDAs:**
Typically, it is best to just allocate the PDA once with `_reserved: [u8; 500]` as its last field to allocate more space than needed and not need reallocations when extending the struct, if we expect to extend the struct on later program upgrades. Another approach for live programs is to deprecate the PDA and use another one such as `ControllerSettings2`, or rather, extend the state in yet another complementary PDA such as `ControllerMinValidations` only with the extra fields. However, the approach used here is not only sensible too but also more reasonable given that we are in a development stage yet.

**Other notes about this instruction:**
Admins should note that this instruction is expected to be called together (same transaction) with another instruction writing to the newly added settings field (in this case, `set_min_validations`).
If this instruction is called alone, the extra bytes added to the `ControllerSettings` PDA will be **zeroed**, meaning there might be inconsistent state. In this case, calling `resize_settings` on its own creates a `min_validation` field equal to `0`, which is otherwise impossible through program logic.

## Settler

### Instructions

#### `create_intent`
Intent's `min_validations` are now set to the maximum of `intent.min_validations` and `controller.min_validations`, following EVM logic.

## Tests

Tests were updated and new cases added accordingly.
Naming was adjusted a bit in `settler.spec.ts` as it differed slightly from the other test file.